### PR TITLE
fix : ResumeMatchResultDTO add similarity_score

### DIFF
--- a/src/main/java/com/example/backend/dto/ResumeMatchResultDTO.java
+++ b/src/main/java/com/example/backend/dto/ResumeMatchResultDTO.java
@@ -17,6 +17,9 @@ public class ResumeMatchResultDTO {
     @Schema(description = "요약", example = "지원자의 기술과 직무 요구가 전반적으로 일치합니다.")
     private String summary;
 
+    @Schema(description = "벡터 유사도(1차 필터링)", example = "0.8196")
+    private double similarity_score;
+
     @Schema(description = "총점", example = "91.2")
     private double total_score;
 

--- a/src/main/java/com/example/backend/pdf/PdfController.java
+++ b/src/main/java/com/example/backend/pdf/PdfController.java
@@ -112,7 +112,6 @@ public class PdfController implements PdfControllerDocs {
         }
     }
 
-    // TODO: 응답형태 페이징객체 논의 필요.
     @GetMapping("/list")
     public ResponseEntity<PdfResponseDTO> getPdf(@AuthenticationPrincipal SecurityUserDto authenticatedUser) {
         if (authenticatedUser == null) {
@@ -122,30 +121,6 @@ public class PdfController implements PdfControllerDocs {
         Long userId = authenticatedUser.getId();
         PdfResponseDTO response = pdfService.getUserPdfs(userId);
 
-        // front에는 이런 형식으로 response 됩니다.
-        /**
-         *
-         * {
-         *   "userId": 3,
-         *   "pdfs": [
-         *     {
-         *       "id": 1,
-         *       "pdfFileName": "3a5b-1234.pdf",
-         *       "mongoObjectId": "6605a2...",
-         *       "uploadedAt": "2025-03-29T10:15:30"
-         *       "pdfUri": "/files/c3bb5efb-ff71-4a08-971d-89c3cc331f78.pdf"
-         *     },
-         *     {
-         *       "id": 2,
-         *       "pdfFileName": "7b2d-abc.pdf",
-         *       "mongoObjectId": "6605a3...",
-         *       "uploadedAt": "2025-03-29T11:25:42"
-         *       "pdfUri": "/files/62d40415-f322-44e9-aebc-b3cf97939831.pdf"
-         *     }
-         *   ]
-         * }
-         *
-         * **/
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/backend/pdf/PdfService.java
+++ b/src/main/java/com/example/backend/pdf/PdfService.java
@@ -262,12 +262,13 @@ public class PdfService {
         ResponseEntity<String> response = restTemplate.postForEntity(fastApiUrl + "/resumes/compare_resume_posting", requestEntity, String.class);
         ObjectMapper objectMapper = new ObjectMapper();
         JsonNode json = objectMapper.readTree(response.getBody());
+        System.out.println("📦 FastAPI 응답 JSON: " + json.toPrettyString());
 
-        // DTO로 변환
+        // DTO로 변환, FastAPI 응답 Null 방어
         OneEoneDTO dto = new OneEoneDTO();
-        dto.setTotal_score(json.get("total_score").asDouble());
-        dto.setSummary(json.get("summary").asText());
-        dto.setGpt_answer(json.get("gpt_answer").asText());
+        dto.setTotal_score(json.has("total_score") ? json.get("total_score").asDouble() : 0.0);
+        dto.setSummary(json.has("summary") ? json.get("summary").asText() : "");
+        dto.setGpt_answer(json.has("gpt_answer") ? json.get("gpt_answer").asText() : "");
 
         List<OneEoneDTO> result = new ArrayList<>();
         result.add(dto);


### PR DESCRIPTION
FastAPI에서 /resumes/compare_resume_posting 응답 JSON에 "total_score" 필드가 없거나 에러메세지 온 경우, 에러뜨길래, 검증해주고 없으면 null세팅하는 부분 추가했습니다. -> pdf service

역직렬화 오류
Unrecognized field "similarity_score" (class com.example.backend.dto.ResumeMatchResultDTO)
-> 이런 오류 나길래, dto에 필드 하나 추가했습니다.